### PR TITLE
contain content

### DIFF
--- a/wall.css
+++ b/wall.css
@@ -75,6 +75,7 @@ body {
 
 .portal {
   box-sizing: border-box;
+  contain: content;
   margin: 0;
   margin-inline-end: 1rem;
   margin-block-end: 1rem;


### PR DESCRIPTION
learning about [contain](https://drafts.csswg.org/css-contain/#propdef-contain) and portal seems like good use case for `content`

> `contain: content` is reasonably "safe" to apply widely; its effects are fairly minor in practice, and most content won’t run afoul of its restrictions. However, because it doesn’t apply size containment, the element can still respond to the size of its contents, which can cause layout-invalidation to percolate further up the tree than desired.