### PR TITLE
slash 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,7 +2,7 @@
 <html lang="en-US">
 <meta charset=utf-8>
 <title>404</title>
-<link rel=stylesheet href=404.css>
+<link rel=stylesheet href=/404.css>
 <meta name="color-scheme" content="dark">
 <meta name="theme-color" content=#404>
 <h1>404</h1>


### PR DESCRIPTION
we absolute slash our [404](https://webmural.com/404) [stylesheet](../blob/master/404.css) to accommodate deep paths online like `/deep/deeper` but i unslashed while locally testing #21 and forgot to reslash before committing. embedding would solve but linked reads well and can cache