### PR TITLE
delete config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,0 @@
-permalink: pretty
-plugins:
-  - jekyll-sitemap


### PR DESCRIPTION
### delete because...

* we don't wanna mislead anyone into jekyll confusion when we're **not** using jekyll
* [`permalink`](https://github.com/ryanve/sluj) setting makes no difference here due to flat structure and github default behavior
* [`jekyll-sitemap`](https://github.com/jekyll/jekyll-sitemap) only had the homepage because it operates per repo. i manually sitemap [`sitemap.txt`](https://webmural.com/sitemap.txt) anyway